### PR TITLE
Fix isNumeric conflict with DMD 2.072 

### DIFF
--- a/src/commando.d
+++ b/src/commando.d
@@ -494,7 +494,7 @@ final class ArgumentParser
 }
 
 private TVal defaultParser( TVal )( string value )
-    if( isNumeric!TVal )
+    if( std.traits.isNumeric!TVal )
 {
     return value.to!TVal;
 }


### PR DESCRIPTION
Does not compile with DMD32 D Compiler v2.072.1 

_Error: std.traits.isNumeric(T)_

see https://github.com/rejectedsoftware/vibe.d/pull/1523/commits/04aa8f7a38c184b918d0d82d62b6a300dd9a9652